### PR TITLE
feat(student): add pagination for instructor’s students and course participant counts

### DIFF
--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -112,6 +112,7 @@ export class CourseService {
     const qb = this.courseRepository.createQueryBuilder('course');
     qb.leftJoinAndSelect('course.category', 'category')
       .leftJoinAndSelect('course.subCategory', 'subCategory')
+      .loadRelationCountAndMap('course.studentCount', 'course.enrollments') // ✅ count enrollments
       .andWhere('course.deleted_at IS NULL'); // filter out soft-deleted
 
     // 🔑 Role-based restrictions

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -30,6 +30,7 @@ import { AuthService } from 'src/auth/auth.service';
 import { Response } from 'express';
 import { AuthGuard } from '@nestjs/passport';
 import { UpdateSecuritySettingsDto } from './dto/security-settings.dto';
+import { Paginate, Paginated, PaginateQuery } from 'nestjs-paginate';
 
 @ApiTags('Users')
 @Controller('users')
@@ -173,9 +174,10 @@ export class UserController {
     description: 'List of students enrolled in instructor’s courses.',
   })
   async getStudentsForInstructor(
+    @Paginate() query: PaginateQuery,
     @Param('userId') instructorId: string,
     @Req() req,
-  ) {
+  ): Promise<Paginated<any>> {
     if (req.user.role === UserRole.INSTRUCTOR) {
       if (req.user.sub !== instructorId) {
         throw new ForbiddenException(
@@ -183,7 +185,7 @@ export class UserController {
         );
       }
     }
-    return this.userService.findStudentsByInstructor(instructorId);
+    return this.userService.findStudentsByInstructor(query, instructorId);
   }
 
   @UseGuards(AuthGuard('jwt'))


### PR DESCRIPTION
- Implemented pagination in the endpoint for fetching students under a given instructor
- Ensured students are returned with profile details and number of enrolled courses
- Added student count per course via relation count mapping
- Improved query efficiency with joins and relation counting
- Updated pagination configs to support filtering/sorting on profile fields